### PR TITLE
Update README to describe Gratitude Journal and setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,59 +1,94 @@
-<p align="center"><a href="https://laravel.com" target="_blank"><img src="https://raw.githubusercontent.com/laravel/art/master/logo-lockup/5%20SVG/2%20CMYK/1%20Full%20Color/laravel-logolockup-cmyk-red.svg" width="400" alt="Laravel Logo"></a></p>
+# Gratitude Journal
 
-<p align="center">
-<a href="https://github.com/laravel/framework/actions"><img src="https://github.com/laravel/framework/workflows/tests/badge.svg" alt="Build Status"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/dt/laravel/framework" alt="Total Downloads"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/v/laravel/framework" alt="Latest Stable Version"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/l/laravel/framework" alt="License"></a>
-</p>
+Gratitude Journal is a Laravel + Inertia (React) app for daily reflection.
 
-## About Laravel
+Core behavior:
+- Write one entry per day with three prompts: person, grace, gratitude.
+- Browse prior entries in History.
+- See optional flashbacks from 1 week ago and 1 year ago.
+- Sign in with passwordless magic links.
+- Work locally-first in the browser (Dexie/IndexedDB) and sync to server when authenticated.
 
-Laravel is a web application framework with expressive, elegant syntax. We believe development must be an enjoyable and creative experience to be truly fulfilling. Laravel takes the pain out of development by easing common tasks used in many web projects, such as:
+## Tech Stack
 
-- [Simple, fast routing engine](https://laravel.com/docs/routing).
-- [Powerful dependency injection container](https://laravel.com/docs/container).
-- Multiple back-ends for [session](https://laravel.com/docs/session) and [cache](https://laravel.com/docs/cache) storage.
-- Expressive, intuitive [database ORM](https://laravel.com/docs/eloquent).
-- Database agnostic [schema migrations](https://laravel.com/docs/migrations).
-- [Robust background job processing](https://laravel.com/docs/queues).
-- [Real-time event broadcasting](https://laravel.com/docs/broadcasting).
+- Backend: Laravel 12, PHP 8.2+
+- Frontend: Inertia.js + React + Vite + Tailwind + daisyUI
+- Database: SQLite by default
+- Auth: Email magic links
 
-Laravel is accessible, powerful, and provides tools required for large, robust applications.
+## Setup
 
-## Learning Laravel
+### 1. Prerequisites
 
-Laravel has the most extensive and thorough [documentation](https://laravel.com/docs) and video tutorial library of all modern web application frameworks, making it a breeze to get started with the framework. You can also check out [Laravel Learn](https://laravel.com/learn), where you will be guided through building a modern Laravel application.
+- PHP 8.2+
+- Composer
+- Node.js + npm
+- SQLite
 
-If you don't feel like reading, [Laracasts](https://laracasts.com) can help. Laracasts contains thousands of video tutorials on a range of topics including Laravel, modern PHP, unit testing, and JavaScript. Boost your skills by digging into our comprehensive video library.
+### 2. Install and bootstrap
 
-## Laravel Sponsors
+```bash
+composer setup
+```
 
-We would like to extend our thanks to the following sponsors for funding Laravel development. If you are interested in becoming a sponsor, please visit the [Laravel Partners program](https://partners.laravel.com).
+`composer setup` will:
+- install PHP dependencies
+- create `.env` from `.env.example` (if missing)
+- generate `APP_KEY`
+- run migrations
+- install frontend dependencies
+- build frontend assets
 
-### Premium Partners
+### 3. Run the app locally
 
-- **[Vehikl](https://vehikl.com)**
-- **[Tighten Co.](https://tighten.co)**
-- **[Kirschbaum Development Group](https://kirschbaumdevelopment.com)**
-- **[64 Robots](https://64robots.com)**
-- **[Curotec](https://www.curotec.com/services/technologies/laravel)**
-- **[DevSquad](https://devsquad.com/hire-laravel-developers)**
-- **[Redberry](https://redberry.international/laravel-development)**
-- **[Active Logic](https://activelogic.com)**
+```bash
+composer dev
+```
 
-## Contributing
+This starts:
+- Laravel web server
+- queue listener
+- Laravel Pail log tailing
+- Vite dev server
 
-Thank you for considering contributing to the Laravel framework! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
+Open `http://127.0.0.1:8000` (or the URL shown by `php artisan serve`).
 
-## Code of Conduct
+## Configuration Notes
 
-In order to ensure that the Laravel community is welcoming to all, please review and abide by the [Code of Conduct](https://laravel.com/docs/contributions#code-of-conduct).
+- Default local DB is SQLite (`DB_CONNECTION=sqlite`).
+- Magic-link emails use the `log` mailer by default (`MAIL_MAILER=log`), so links are written to `storage/logs/laravel.log`.
+Main routes:
+- `/today`
+- `/history`
+- `/settings` (authenticated)
 
-## Security Vulnerabilities
+## Testing
 
-If you discover a security vulnerability within Laravel, please send an e-mail to Taylor Otwell via [taylor@laravel.com](mailto:taylor@laravel.com). All security vulnerabilities will be promptly addressed.
+### Run all tests
 
-## License
+```bash
+composer test
+```
 
-The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
+or:
+
+```bash
+php artisan test
+```
+
+### Run specific tests
+
+```bash
+php artisan test --filter=ExampleTest
+```
+
+### Test environment details
+
+- PHPUnit is configured in `phpunit.xml`.
+- Tests run with `APP_ENV=testing`.
+- DB is in-memory SQLite (`DB_DATABASE=:memory:`).
+- Mailer is `array` in tests (emails are not sent).
+
+Current baseline tests are in:
+- `tests/Feature`
+- `tests/Unit`


### PR DESCRIPTION
Summary
- replace the default Laravel README with an overview of Gratitude Journal, its core behavior, and tech stack
- document prerequisites, setup commands, local run instructions, and configuration notes tailored to this project
- add a testing section that summarizes available commands and environment details

Testing
- Not run (not requested)