### PR TITLE
magic links are working

### DIFF
--- a/app/Http/Controllers/Auth/MagicLinkController.php
+++ b/app/Http/Controllers/Auth/MagicLinkController.php
@@ -44,11 +44,13 @@ class MagicLinkController extends Controller
             'expires_at' => $expiresAt,
         ]);
 
-        $url = URL::temporarySignedRoute(
+        $relativeSignedPath = URL::temporarySignedRoute(
             'auth.magic.consume',
             $expiresAt,
             ['token' => $rawToken],
+            absolute: false,
         );
+        $url = url($relativeSignedPath);
 
         Mail::to($email)->send(new MagicLinkMail($url));
 

--- a/app/Http/Middleware/NormalizeHtmlEscapedSignature.php
+++ b/app/Http/Middleware/NormalizeHtmlEscapedSignature.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class NormalizeHtmlEscapedSignature
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $queryString = (string) $request->server->get('QUERY_STRING', '');
+
+        if (str_contains($queryString, 'amp;signature=')) {
+            $request->server->set(
+                'QUERY_STRING',
+                preg_replace('/(^|&)amp;signature=/', '$1signature=', $queryString, 1) ?? $queryString,
+            );
+        }
+
+        if (! $request->query->has('signature') && $request->query->has('amp;signature')) {
+            $request->query->set('signature', (string) $request->query->get('amp;signature'));
+            $request->query->remove('amp;signature');
+        }
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Middleware\HandleInertiaRequests;
+use App\Http\Middleware\NormalizeHtmlEscapedSignature;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -12,9 +13,14 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        $middleware->web(append: [
-            HandleInertiaRequests::class,
-        ]);
+        $middleware->web(
+            prepend: [
+                NormalizeHtmlEscapedSignature::class,
+            ],
+            append: [
+                HandleInertiaRequests::class,
+            ],
+        );
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,7 +18,7 @@ Route::middleware('throttle:5,15')->group(function () {
 });
 
 Route::get('/auth/magic-link/{token}', [MagicLinkController::class, 'consume'])
-    ->middleware('signed')
+    ->middleware('signed:relative')
     ->name('auth.magic.consume');
 Route::post('/logout', [MagicLinkController::class, 'logout'])
     ->middleware('auth')

--- a/tests/Feature/MagicLinkConsumeTest.php
+++ b/tests/Feature/MagicLinkConsumeTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\MagicLoginToken;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\URL;
+use Tests\TestCase;
+
+class MagicLinkConsumeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_magic_link_can_be_consumed_with_different_host_and_scheme(): void
+    {
+        $user = User::factory()->create();
+        $rawToken = str_repeat('a', 64);
+        $expiresAt = now()->addMinutes(30);
+
+        $magicToken = MagicLoginToken::query()->create([
+            'user_id' => $user->id,
+            'token_hash' => hash('sha256', $rawToken),
+            'expires_at' => $expiresAt,
+        ]);
+
+        $signedUrl = URL::temporarySignedRoute(
+            'auth.magic.consume',
+            $expiresAt,
+            ['token' => $rawToken],
+            absolute: false,
+        );
+
+        $parts = parse_url($signedUrl);
+        $pathWithQuery = $parts['path'].'?'.$parts['query'];
+
+        $response = $this
+            ->withServerVariables([
+                'HTTP_HOST' => 'alt.example.test',
+                'HTTPS' => 'on',
+            ])
+            ->get($pathWithQuery);
+
+        $response->assertRedirect(route('today.show'));
+        $this->assertAuthenticatedAs($user);
+        $this->assertNotNull($magicToken->fresh()->used_at);
+    }
+
+    public function test_magic_link_rejects_tampered_signature(): void
+    {
+        $user = User::factory()->create();
+        $rawToken = str_repeat('b', 64);
+        $expiresAt = now()->addMinutes(30);
+
+        MagicLoginToken::query()->create([
+            'user_id' => $user->id,
+            'token_hash' => hash('sha256', $rawToken),
+            'expires_at' => $expiresAt,
+        ]);
+
+        $signedUrl = URL::temporarySignedRoute(
+            'auth.magic.consume',
+            $expiresAt,
+            ['token' => $rawToken],
+            absolute: false,
+        );
+
+        $parts = parse_url($signedUrl);
+        parse_str($parts['query'], $query);
+        $query['signature'] = strrev($query['signature']);
+        $tamperedUrl = $parts['path'].'?'.http_build_query($query);
+
+        $response = $this->get($tamperedUrl);
+
+        $response->assertForbidden();
+        $this->assertGuest();
+    }
+
+    public function test_magic_link_accepts_html_escaped_signature_param_name(): void
+    {
+        $user = User::factory()->create();
+        $rawToken = str_repeat('c', 64);
+        $expiresAt = now()->addMinutes(30);
+
+        $magicToken = MagicLoginToken::query()->create([
+            'user_id' => $user->id,
+            'token_hash' => hash('sha256', $rawToken),
+            'expires_at' => $expiresAt,
+        ]);
+
+        $signedUrl = URL::temporarySignedRoute(
+            'auth.magic.consume',
+            $expiresAt,
+            ['token' => $rawToken],
+            absolute: false,
+        );
+        $htmlEscapedUrl = str_replace('&signature=', '&amp;signature=', $signedUrl);
+
+        $response = $this->get($htmlEscapedUrl);
+
+        $response->assertRedirect(route('today.show'));
+        $this->assertAuthenticatedAs($user);
+        $this->assertNotNull($magicToken->fresh()->used_at);
+    }
+}


### PR DESCRIPTION
This pull request enhances the handling of magic link authentication by improving signature validation, supporting relative signed URLs, and adding middleware to normalize HTML-escaped signature parameters. It also introduces comprehensive tests to ensure robust behavior across different scenarios.

**Magic link authentication improvements:**

* Changed magic link generation in `MagicLinkController` to use relative signed URLs and convert them to absolute URLs, allowing links to work across different hosts and schemes.
* Updated the magic link route to use the `signed:relative` middleware, ensuring proper validation of relative signed URLs.

**Middleware enhancements:**

* Added new middleware `NormalizeHtmlEscapedSignature` to handle cases where the signature parameter is HTML-escaped (e.g., `amp;signature`), normalizing it for validation.
* Registered `NormalizeHtmlEscapedSignature` middleware to run before other web middleware, ensuring signature normalization happens early in the request lifecycle [[1]](diffhunk://#diff-10bc2462d34ebc59a5d482a1faca04ce74f6df89fcc2ef8bfb17b939647ea518R4) [[2]](diffhunk://#diff-10bc2462d34ebc59a5d482a1faca04ce74f6df89fcc2ef8bfb17b939647ea518L15-R23).

**Testing improvements:**

* Added feature tests in `MagicLinkConsumeTest` to verify magic link consumption with different hosts/schemes, rejection of tampered signatures, and acceptance of HTML-escaped signature parameter names.