### PR TITLE
remove timezone and add cal reminder

### DIFF
--- a/app/Http/Controllers/SettingsController.php
+++ b/app/Http/Controllers/SettingsController.php
@@ -4,37 +4,23 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Validation\Rule;
 use Inertia\Inertia;
 use Inertia\Response;
 
 class SettingsController extends Controller
 {
-    private array $timezones = [
-        'America/New_York',
-        'America/Chicago',
-        'America/Denver',
-        'America/Los_Angeles',
-        'Europe/London',
-        'Europe/Berlin',
-        'Asia/Tokyo',
-    ];
-
     public function show(Request $request): Response
     {
         $user = $request->user();
 
         return Inertia::render('Settings', [
-            'timezone' => $user->timezone,
             'show_flashbacks' => (bool) $user->show_flashbacks,
-            'timezones' => $this->timezones,
         ]);
     }
 
     public function update(Request $request): RedirectResponse
     {
         $validated = $request->validate([
-            'timezone' => ['required', 'string', Rule::in($this->timezones)],
             'show_flashbacks' => ['required', 'boolean'],
         ]);
 

--- a/resources/js/Pages/Settings.tsx
+++ b/resources/js/Pages/Settings.tsx
@@ -1,18 +1,55 @@
 import { Head, useForm, usePage } from '@inertiajs/react';
+import { useMemo, useState } from 'react';
 import AppShell from '../Components/AppShell';
 
 type PageProps = {
-    timezone: string;
     show_flashbacks: boolean;
-    timezones: string[];
 };
 
 export default function Settings() {
     const { props } = usePage<PageProps>();
+    const [reminderTime, setReminderTime] = useState('20:00');
     const form = useForm({
-        timezone: props.timezone,
         show_flashbacks: props.show_flashbacks,
     });
+
+    const reminderIcsHref = useMemo(() => {
+        const safeTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+        const now = new Date();
+        const dateParts = new Intl.DateTimeFormat('en-CA', {
+            timeZone: safeTimezone,
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+        }).formatToParts(now);
+
+        const year = dateParts.find((part) => part.type === 'year')?.value ?? '1970';
+        const month = dateParts.find((part) => part.type === 'month')?.value ?? '01';
+        const day = dateParts.find((part) => part.type === 'day')?.value ?? '01';
+
+        const [hour = '20', minute = '00'] = reminderTime.split(':');
+        const dtStart = `${year}${month}${day}T${hour}${minute}00`;
+        const stamp = now.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
+        const uid = `gratitude-daily-reminder-${safeTimezone}-${hour}${minute}`;
+
+        const calendar = [
+            'BEGIN:VCALENDAR',
+            'VERSION:2.0',
+            'PRODID:-//Gratitude//Daily Reminder//EN',
+            'CALSCALE:GREGORIAN',
+            'BEGIN:VEVENT',
+            `UID:${uid}`,
+            `DTSTAMP:${stamp}`,
+            `DTSTART;TZID=${safeTimezone}:${dtStart}`,
+            'RRULE:FREQ=DAILY',
+            'SUMMARY:Daily Gratitude Reminder',
+            'DESCRIPTION:Open Gratitude and write today\\,s entry.',
+            'END:VEVENT',
+            'END:VCALENDAR',
+        ].join('\r\n');
+
+        return `data:text/calendar;charset=utf-8,${encodeURIComponent(calendar)}`;
+    }, [reminderTime]);
 
     return (
         <AppShell>
@@ -21,21 +58,6 @@ export default function Settings() {
             <div className="card bg-base-100 shadow-sm">
                 <div className="card-body gap-4">
                     <h1 className="card-title text-2xl">Settings</h1>
-
-                    <label className="form-control w-full max-w-xs gap-2">
-                        <span className="label-text">Timezone</span>
-                        <select
-                            className="select select-bordered"
-                            value={form.data.timezone}
-                            onChange={(event) => form.setData('timezone', event.target.value)}
-                        >
-                            {props.timezones.map((timezone) => (
-                                <option key={timezone} value={timezone}>
-                                    {timezone}
-                                </option>
-                            ))}
-                        </select>
-                    </label>
 
                     <label className="label cursor-pointer justify-start gap-3">
                         <input
@@ -57,11 +79,28 @@ export default function Settings() {
                 </div>
             </div>
 
-            <div className="card bg-base-100 shadow-sm opacity-70">
+            <div className="card bg-base-100 shadow-sm">
                 <div className="card-body">
                     <h2 className="card-title">Reminders</h2>
-                    <p>Push and SMS reminders are outside MVP. Placeholder only.</p>
-                    <button className="btn btn-disabled btn-sm w-fit">Coming later</button>
+                    <p>Choose a daily reminder time, then add it to your calendar.</p>
+
+                    <label className="form-control w-full max-w-xs gap-2">
+                        <span className="label-text">Reminder time</span>
+                        <input
+                            type="time"
+                            className="input input-bordered"
+                            value={reminderTime}
+                            onChange={(event) => setReminderTime(event.target.value)}
+                        />
+                    </label>
+
+                    <a
+                        className="btn btn-outline btn-sm w-fit"
+                        href={reminderIcsHref}
+                        download="gratitude-daily-reminder.ics"
+                    >
+                        Download daily reminder (.ics)
+                    </a>
                 </div>
             </div>
         </AppShell>


### PR DESCRIPTION
This pull request removes user-selectable timezones from the settings and introduces a new feature allowing users to download a customizable daily calendar reminder (.ics) file. The reminders section is now functional, letting users choose a time for their daily reminder and add it to their calendar.

**Settings simplification:**

* Removed the timezone selection feature from both the backend (`SettingsController.php`) and frontend (`Settings.tsx`), including validation and the list of available timezones. [[1]](diffhunk://#diff-32d3d97e441a0941f3ac481b391427cd0ab9afae6bdd3320af0aaebd80bc3a0bL7-L37) [[2]](diffhunk://#diff-cffce6eec8a63c4eec056f241e48aaf82a4d268dc48589fb44f0aa9a9780cb62R2-R53) [[3]](diffhunk://#diff-cffce6eec8a63c4eec056f241e48aaf82a4d268dc48589fb44f0aa9a9780cb62L25-L39)

**Reminders feature:**

* Replaced the placeholder reminders section with a functional UI that lets users select a daily reminder time and download a corresponding `.ics` calendar file. The calendar file is dynamically generated based on the selected time and the user's browser timezone. [[1]](diffhunk://#diff-cffce6eec8a63c4eec056f241e48aaf82a4d268dc48589fb44f0aa9a9780cb62R2-R53) [[2]](diffhunk://#diff-cffce6eec8a63c4eec056f241e48aaf82a4d268dc48589fb44f0aa9a9780cb62L60-R103)